### PR TITLE
Docker image enhancements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,6 @@
 **/.git
 .env
+.github
+README.md
+LICENSE
+*.example.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
-FROM golang:1.17.3-bullseye
+FROM denismakogon/ffmpeg-alpine:4.0-buildstage as build-stage
+FROM golang:1.17.6-alpine
+
+# Copy ffmpeg runtime https://github.com/denismakogon/ffmpeg-alpine#custom-runtime
+COPY --from=build-stage /tmp/fakeroot/bin /usr/local/bin
+COPY --from=build-stage /tmp/fakeroot/share /usr/local/share
+COPY --from=build-stage /tmp/fakeroot/include /usr/local/include
+COPY --from=build-stage /tmp/fakeroot/lib /usr/local/lib
 
 WORKDIR /app
 COPY go.mod .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,6 @@ services:
       context: '.'
     volumes:
       - './config.json:/app/config.json'
+      - './channels.json:/app/channels.json'
     ports:
       - '5004:5004'


### PR DESCRIPTION
- Use alpine in docker image
image size diff:
```
alpine with ffmpeg:
plex-dvr-hls_app              latest            0c827c5f7e7d   9 minutes ago   524MB

debian with ffmpeg:
plex-dvr-hls_app              latest            5f2b4584c7f3   8 minutes ago   1.08GB
```
- Add missing ffmpeg runtime to docker