### PR TITLE
build(docker): Use stock Alpine image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,3 +29,50 @@ jobs:
           GOOS=windows GOARCH=386 go build -v -o ${GITHUB_REPOSITORY##*/}-windows-i386.exe ./cmd/...
           GOOS=windows GOARCH=arm go build -v -o ${GITHUB_REPOSITORY##*/}-windows-arm.exe ./cmd/...
           GOOS=windows GOARCH=arm64 go build -v -o ${GITHUB_REPOSITORY##*/}-windows-arm64.exe ./cmd/...
+  build-docker:
+    name: Build Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/duncanleo/plex-dvr-hls
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,priority=1000,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and Push
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          pull: true
+          push: false
+          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and Push
+      - name: Build without Pushing
         id: docker_build
         uses: docker/build-push-action@v5
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine as app-build
+FROM golang:1.21-alpine3.19 as app-build
 
 WORKDIR /app
 COPY go.mod .
@@ -10,9 +10,9 @@ COPY . .
 
 RUN go build -o /bin/app cmd/*.go
 
-FROM collelog/ffmpeg:4.4-alpine-vaapi-amd64
+FROM alpine:3.19
 
-RUN apk add ffmpeg
+RUN apk add ffmpeg intel-media-driver
 
 COPY --from=app-build /bin/app /bin/app
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,12 @@ RUN go build -o /bin/app cmd/*.go
 
 FROM alpine:3.19
 
-RUN apk add ffmpeg intel-media-driver
+ARG TARGETPLATFORM
+
+RUN case ${TARGETPLATFORM:-linux/amd64} in \
+        "linux/amd64") apk add ffmpeg intel-media-driver ;; \
+        *)             apk add ffmpeg ;; \
+    esac
 
 COPY --from=app-build /bin/app /bin/app
 WORKDIR /app


### PR DESCRIPTION
# Purpose
This PR replaces the base of the Docker image with stock Alpine 3.19.

Since Alpine's `ffmpeg` package already supports VAAPI (for linux/amd64), it can be paired with Alpine's `intel-media-driver` package to provide ffmpeg with VAAPI support.

For linux/arm64, only `ffmpeg` will be installed.