### PR TITLE
Specify XML encoding in template as UTF-8

### DIFF
--- a/templates/xmltv.tmpl
+++ b/templates/xmltv.tmpl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE tv SYSTEM "xmltv.dtd">
 
 <tv source-info-url="http://www.schedulesdirect.org/" source-info-name="Schedules Direct" generator-info-name="XMLTV/$Id: tv_grab_na_dd.in,v 1.70 2008/03/03 15:21:41 rmeden Exp $" generator-info-url="http://www.xmltv.org/">


### PR DESCRIPTION
The output from Go is UTF-8, so we should specify that in the <xml> tag of the template.
This is required for Plex to display Japanese.

With `encoding="ISO-8859-1"` the guide shows as mojibake.
After changing to `encoding="UTF-8"`, the guide appears correctly:
<img width=500 src=https://github.com/user-attachments/assets/93dc7891-47a4-4e13-a555-01b3c5c8e781>