### PR TITLE
feat: support optional custom Referer per-channel

### DIFF
--- a/config/channels.go
+++ b/config/channels.go
@@ -25,6 +25,7 @@ type Channel struct {
 
 	// UserAgent is a custom UA string that will be used by FFMPEG to make requests to the stream URL.
 	UserAgent        *string `json:"userAgent,omitempty"`
+    Referer          *string `json:"referer,omitempty"`
     Icon             *string      `json:"icon,omitempty"`
 }
 

--- a/config/channels.go
+++ b/config/channels.go
@@ -26,7 +26,7 @@ type Channel struct {
 	// UserAgent is a custom UA string that will be used by FFMPEG to make requests to the stream URL.
 	UserAgent        *string `json:"userAgent,omitempty"`
     Referer          *string `json:"referer,omitempty"`
-    Icon             *string      `json:"icon,omitempty"`
+    Icon             *string `json:"icon,omitempty"`
 }
 
 var (

--- a/routes/stream.go
+++ b/routes/stream.go
@@ -47,6 +47,14 @@ func Stream(c *gin.Context) {
 		)
 	}
 
+	if channel.Referer != nil {
+		ffmpegArgs = append(
+			ffmpegArgs,
+			"-headers",
+			fmt.Sprintf("Referer: %s", *channel.Referer),
+		)
+	}
+
 	switch config.Cfg.GetEncoderProfile() {
 	case config.EncoderProfileVAAPI:
 		ffmpegArgs = append(


### PR DESCRIPTION
Along with user-agent, referer seems to be a header that quite a few sites require (at least in my experience) - added the ability to optionally specify it on a per-channel basis (exactly like user-agent).

Could maybe also/alternatively add the option for an unspecified number of custom headers for particularly picky sites? Would help to cover all cases.