### PR TITLE
feat: support channel id overrides

### DIFF
--- a/channels.example.json
+++ b/channels.example.json
@@ -5,6 +5,7 @@
   },
   {
     "name": "PGA Tour on CBS",
+    "id": 12, 
     "url": "http://cbssportsliveios-i.akamaihd.net/hls/live/207523/pgatour_simulcast/desktop.m3u8",
     "proxy": {
       "host": "proxy.somewhere.com:3128",

--- a/config/channels.go
+++ b/config/channels.go
@@ -19,6 +19,7 @@ type ProxyConfig struct {
 
 type Channel struct {
 	Name             string       `json:"name"`
+	ID		 int	      `json:"id"`
 	URL              string       `json:"url"`
 	ProxyConfig      *ProxyConfig `json:"proxy"`
 	DisableTranscode bool         `json:"disableTranscode"`

--- a/routes/xmltv.go
+++ b/routes/xmltv.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"text/template"
 	"time"
+	"slices"
 
 	"github.com/duncanleo/plex-dvr-hls/config"
 	"github.com/gin-gonic/gin"
@@ -26,11 +27,26 @@ type Programme struct {
 func XMLTV(c *gin.Context) {
 	var channels []ChannelSimplified
 
+	var channel_numbers []int
+
 	for index, channel := range config.Channels {
+		var channel_number int = index + 1
+		if channel.ID != 0 {
+			channel_number = channel.ID
+		}
+
+		for slices.Contains(channel_numbers, channel_number){
+			channel_number++
+		}
+		channel_numbers = append(
+			channel_numbers,
+			channel_number,
+		)
+
 		channels = append(
 			channels,
 			ChannelSimplified{
-				ID:   index + 1,
+				ID:   channel_number,
 				Name: channel.Name,
 				Icon: channel.Icon,
 			},


### PR DESCRIPTION
Adding ability to specify channel IDs through the channels.json file.

If a channel with the specified number already exists, we use the next available channel number.