### PR TITLE
fix: stream reliability, mutex safety, template embed, and test coverage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,5 @@ RUN case ${TARGETPLATFORM:-linux/amd64} in \
     esac
 
 COPY --from=app-build /bin/app /bin/app
-WORKDIR /app
-
-COPY templates/ ./templates/
 
 ENTRYPOINT ["/bin/app"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This web server emulates a SiliconDust HDHomeRun by its HTTP API for use with Pl
 - XMLTV file generation (generic 24/7 programme per channel)
 - Per-channel video/audio passthrough (skip re-encoding for better quality)
 - Per-channel proxy, custom User-Agent, and Referer support
-- Automatic ffmpeg restart on upstream stream drops (fixed-delay restart with cap on rapid short-lived exits)
+- Automatic ffmpeg restart on upstream stream drops (2s retry delay; gives up after 3 consecutive exits that each lasted under 10s)
 - Hot-reload of `channels.json` without restart
 
 ### Running
@@ -63,9 +63,16 @@ services:
      | `proxy.host` | string | HTTP proxy host and port (e.g. `proxy.example.com:3128`) |
      | `proxy.username` | string | Proxy authentication username |
      | `proxy.password` | string | Proxy authentication password |
-4. Copy the `templates` folder from this repository into the working directory (alongside the two JSON files)
-5. Add the server to the Plex DVR e.g. `http://<ip of machine>:5004`.
+4. Add the server to the Plex DVR e.g. `http://<ip of machine>:5004`.
    - When prompted for an Electronic Programme Guide, you can either use one if it's available, or use the auto-generated one by entering `http://<ip of machine>:5004/xmltv`
+
+### Environment Variables
+
+| Variable | Description |
+|---|---|
+| `PORT` | Port to listen on (default: `5004`) |
+| `PLAYLIST` | URL or path to an M3U playlist. When set, channels are loaded from the playlist instead of `channels.json`. |
+| `UA` | User-Agent sent when fetching the M3U playlist (default: Chrome UA string) |
 
 ### Development
 1. Clone the repo

--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@ This web server emulates a SiliconDust HDHomeRun by its HTTP API for use with Pl
 
 ### Features
 - Multiple channels
-- XMLTV file generation (it just creates a generic 24/7 programme for each available channel)
+- XMLTV file generation (generic 24/7 programme per channel)
+- Per-channel video/audio passthrough (skip re-encoding for better quality)
+- Per-channel proxy, custom User-Agent, and Referer support
+- Automatic ffmpeg restart on upstream stream drops (fixed-delay restart with cap on rapid short-lived exits)
+- Hot-reload of `channels.json` without restart
 
 ### Running
 ##### Docker
@@ -46,6 +50,19 @@ services:
    - **Optional:** Set `device_id` to a specific value (e.g. `"30480554"`) to maintain a stable device ID. If omitted, a random ID will be generated on first run and automatically saved to `.device_id` for persistence across restarts. Priority order: `config.json` > `.device_id` file > auto-generate new.
 3. Create a `channels.json` and fill in the necessary.
    - A sample `channels.example.json` is available on GitHub.
+   - Each channel supports the following fields:
+     | Field | Type | Description |
+     |---|---|---|
+     | `name` | string | Display name shown in Plex |
+     | `url` | string | Stream URL (M3U8, RTSP, or any ffmpeg-supported input) |
+     | `disableTranscode` | bool | Pass video through unchanged (`-c:v copy`) instead of re-encoding |
+     | `disableAudioTranscode` | bool | Pass audio through unchanged (`-c:a copy`) instead of re-encoding at 256k |
+     | `userAgent` | string | Custom `User-Agent` header sent to the stream source |
+     | `referer` | string | Custom `Referer` header sent to the stream source |
+     | `icon` | string | URL to channel logo (used in XMLTV EPG) |
+     | `proxy.host` | string | HTTP proxy host and port (e.g. `proxy.example.com:3128`) |
+     | `proxy.username` | string | Proxy authentication username |
+     | `proxy.password` | string | Proxy authentication password |
 4. Copy the `templates` folder from this repository into the working directory (alongside the two JSON files)
 5. Add the server to the Plex DVR e.g. `http://<ip of machine>:5004`.
    - When prompted for an Electronic Programme Guide, you can either use one if it's available, or use the auto-generated one by entering `http://<ip of machine>:5004/xmltv`

--- a/channels.example.json
+++ b/channels.example.json
@@ -1,9 +1,7 @@
 [
   {
     "name": "Al Jazeera English",
-    "url": "http://aljazeera-eng-hd-live.hls.adaptive.level3.net/aljazeera/english2/index.m3u8",
-    "disableTranscode": true,
-    "disableAudioTranscode": true
+    "url": "http://aljazeera-eng-hd-live.hls.adaptive.level3.net/aljazeera/english2/index.m3u8"
   },
   {
     "name": "PGA Tour on CBS",
@@ -13,5 +11,14 @@
       "username": "",
       "password": ""
     }
+  },
+  {
+    "name": "Example with all optional fields",
+    "url": "rtsp://example.com/stream",
+    "disableTranscode": true,
+    "disableAudioTranscode": true,
+    "userAgent": "Mozilla/5.0",
+    "referer": "https://example.com",
+    "icon": "https://example.com/icon.png"
   }
 ]

--- a/channels.example.json
+++ b/channels.example.json
@@ -1,7 +1,9 @@
 [
   {
     "name": "Al Jazeera English",
-    "url": "http://aljazeera-eng-hd-live.hls.adaptive.level3.net/aljazeera/english2/index.m3u8"
+    "url": "http://aljazeera-eng-hd-live.hls.adaptive.level3.net/aljazeera/english2/index.m3u8",
+    "disableTranscode": true,
+    "disableAudioTranscode": true
   },
   {
     "name": "PGA Tour on CBS",

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,10 +1,16 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
+	"syscall"
+	"time"
 
 	"github.com/duncanleo/plex-dvr-hls/config"
 	"github.com/duncanleo/plex-dvr-hls/routes"
@@ -23,6 +29,11 @@ func main() {
 		}
 	}
 
+	// serverCtx is cancelled on shutdown to signal active streams to kill their
+	// ffmpeg processes before the process exits.
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+	defer serverCancel()
+
 	r := gin.Default()
 	r.SetTrustedProxies(nil)
 
@@ -30,10 +41,42 @@ func main() {
 	r.GET("/discover.json", routes.Discover)
 	r.GET("/lineup.json", routes.Lineup)
 	r.GET("/lineup_status.json", routes.LineupStatus)
-	r.GET("/stream/:channelID", routes.Stream)
+	r.GET("/stream/:channelID", routes.StreamWithContext(serverCtx))
 	r.GET("/xmltv", routes.XMLTV)
 
-	log.Printf("Starting '%s' tuner with encoder profile %s\n", config.Cfg.Name, config.Cfg.GetEncoderProfile())
+	srv := &http.Server{
+		Addr:    fmt.Sprintf(":%d", port),
+		Handler: r,
+	}
 
-	r.Run(fmt.Sprintf(":%d", port))
+	serverErr := make(chan error, 1)
+	go func() {
+		log.Printf("Starting '%s' tuner with encoder profile %s\n", config.Cfg.Name, config.Cfg.GetEncoderProfile())
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serverErr <- err
+		}
+	}()
+
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+
+	select {
+	case sig := <-quit:
+		log.Printf("Received signal %v, shutting down\n", sig)
+	case err := <-serverErr:
+		log.Printf("Server error: %v — shutting down\n", err)
+	}
+
+	// Cancel serverCtx first: signals active stream handlers to kill their
+	// ffmpeg processes instead of waiting for them to drain naturally.
+	serverCancel()
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		log.Printf("Server shutdown timed out (%v), forcing close\n", err)
+		_ = srv.Close()
+		os.Exit(1)
+	}
+	log.Println("Server stopped")
 }

--- a/config/channels.go
+++ b/config/channels.go
@@ -53,7 +53,7 @@ func LoadChannelsFromPl(location string) error {
 	parser := m3uparser.M3uParser{UserAgent: userAgent, Timeout: 60}
 	parser.ParseM3u(location, true, true)
 	streams := parser.GetStreamsSlice()
-	var chs []Channel
+	var channels []Channel
 	for _, st := range streams {
 		title, ok1 := st["title"].(string)
 		url, ok2 := st["url"].(string)
@@ -61,12 +61,12 @@ func LoadChannelsFromPl(location string) error {
 			log.Printf("[PLAYLIST] skipping malformed entry: title=%v url=%v", st["title"], st["url"])
 			continue
 		}
-		chs = append(chs, Channel{Name: title, URL: url, UserAgent: &userAgent})
+		channels = append(channels, Channel{Name: title, URL: url, UserAgent: &userAgent})
 	}
-	if len(chs) == 0 {
+	if len(channels) == 0 {
 		return errors.New("No streams in playlist")
 	}
-	SetChannels(chs)
+	SetChannels(channels)
 	return nil
 }
 
@@ -179,16 +179,16 @@ func loadChannelsFromFile(path string) error {
 	}
 	defer file.Close()
 
-	var chs []Channel
-	if err := json.NewDecoder(file).Decode(&chs); err != nil {
+	var channels []Channel
+	if err := json.NewDecoder(file).Decode(&channels); err != nil {
 		return err
 	}
 
-	if len(chs) == 0 {
+	if len(channels) == 0 {
 		return errors.New("channels.json decoded to empty list — keeping previous channels")
 	}
 
-	SetChannels(chs)
+	SetChannels(channels)
 	log.Println("Channels reloaded successfully")
 	return nil
 }

--- a/config/channels.go
+++ b/config/channels.go
@@ -7,8 +7,9 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
-    "github.com/fsnotify/fsnotify"
+	"github.com/fsnotify/fsnotify"
 	m3uparser "github.com/pawanpaudel93/go-m3u-parser/m3uparser"
 )
 
@@ -19,96 +20,177 @@ type ProxyConfig struct {
 }
 
 type Channel struct {
-	Name             string       `json:"name"`
-	URL              string       `json:"url"`
-	ProxyConfig      *ProxyConfig `json:"proxy"`
-	DisableTranscode bool         `json:"disableTranscode"`
+	Name                  string       `json:"name"`
+	URL                   string       `json:"url"`
+	ProxyConfig           *ProxyConfig `json:"proxy"`
+	DisableTranscode      bool         `json:"disableTranscode"`
+	DisableAudioTranscode bool         `json:"disableAudioTranscode"`
 
 	// UserAgent is a custom UA string that will be used by FFMPEG to make requests to the stream URL.
-	UserAgent        *string `json:"userAgent,omitempty"`
-    Referer          *string `json:"referer,omitempty"`
-    Icon             *string `json:"icon,omitempty"`
+	UserAgent *string `json:"userAgent,omitempty"`
+	Referer   *string `json:"referer,omitempty"`
+	Icon      *string `json:"icon,omitempty"`
 }
 
 var (
-	Channels []Channel
+	channels []Channel
 	mu       sync.Mutex
 )
 
+// SetChannels replaces the channel list under the mutex.
+// Exported so route tests can inject test data without bypassing the lock.
+func SetChannels(c []Channel) {
+	mu.Lock()
+	channels = c
+	mu.Unlock()
+}
+
 func LoadChannelsFromPl(location string) error {
-    var userAgent = os.Getenv("UA")
-    if len(userAgent) == 0 {
-      userAgent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36"
+	var userAgent = os.Getenv("UA")
+	if len(userAgent) == 0 {
+		userAgent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36"
 	}
 	parser := m3uparser.M3uParser{UserAgent: userAgent, Timeout: 60}
-	parser.ParseM3u(location,true,true)
+	parser.ParseM3u(location, true, true)
 	streams := parser.GetStreamsSlice()
-	if len(streams) > 0 {
-	    for _, st := range streams {
-			ch := Channel{Name: st["title"].(string), URL: st["url"].(string), UserAgent: &userAgent}
-			Channels = append(Channels,ch)
-		} 
-		if len(Channels) > 0 {
-			return nil
+	var chs []Channel
+	for _, st := range streams {
+		title, ok1 := st["title"].(string)
+		url, ok2 := st["url"].(string)
+		if !ok1 || !ok2 || title == "" || url == "" {
+			log.Printf("[PLAYLIST] skipping malformed entry: title=%v url=%v", st["title"], st["url"])
+			continue
 		}
+		chs = append(chs, Channel{Name: title, URL: url, UserAgent: &userAgent})
 	}
-	return errors.New("No streams in playlist")
+	if len(chs) == 0 {
+		return errors.New("No streams in playlist")
+	}
+	SetChannels(chs)
+	return nil
 }
 
 func WatchChannelsFile() {
-    watcher, err := fsnotify.NewWatcher()
-    if err != nil {
-        log.Fatal(err)
-    }
-    defer watcher.Close()
+	backoff := time.Second
+	for {
+		watcher, err := fsnotify.NewWatcher()
+		if err != nil {
+			log.Printf("channels.json watcher setup failed (%v), retrying in %v", err, backoff)
+			time.Sleep(backoff)
+			backoff = min(backoff*2, 30*time.Second)
+			continue
+		}
 
-    err = watcher.Add("channels.json")
-    if err != nil {
-        log.Fatal(err)
-    }
+		if err = watcher.Add("channels.json"); err != nil {
+			watcher.Close()
+			log.Printf("channels.json watcher add failed (%v), retrying in %v", err, backoff)
+			time.Sleep(backoff)
+			backoff = min(backoff*2, 30*time.Second)
+			continue
+		}
 
-    for {
-        select {
-        case event, ok := <-watcher.Events:
-            if !ok {
-                return
-            }
-            if event.Has(fsnotify.Write) {
-                log.Println("Detected change in channels.json, reloading channels")
-                err := LoadChannels()
-                if err != nil {
-                    log.Printf("Error reloading channels: %s\n", err)
-                }
-            }
-        case err, ok := <-watcher.Errors:
-            if !ok {
-                return
-            }
-            log.Printf("Watcher error: %s\n", err)
-        }
-    }
+		backoff = time.Second // reset on successful setup
+		log.Println("channels.json watcher active")
+		runWatchLoop(watcher, LoadChannels)
+		watcher.Close()
+		log.Println("channels.json watcher restarting...")
+	}
+}
+
+// runWatchLoop processes fsnotify events until the watcher channel closes.
+// reload is injected rather than calling LoadChannels directly so tests can
+// assert it was called without touching the filesystem.
+func runWatchLoop(watcher *fsnotify.Watcher, reload func() error) {
+	for {
+		select {
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return
+			}
+			// Write covers in-place edits.
+			if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
+				log.Println("Detected change in channels.json, reloading channels")
+				if err := reload(); err != nil {
+					log.Printf("Error reloading channels: %s\n", err)
+				}
+			}
+			// Atomic saves (temp-file-then-rename) fire Remove or Rename on the old
+			// inode — not Create, which is a directory-level event. Reload first
+			// (the new file is already in place), then re-add the watch for the new
+			// inode. If re-add fails, return so the outer loop rebuilds a fresh watcher.
+			if event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) {
+				log.Println("Detected atomic save of channels.json, reloading channels")
+				if err := reload(); err != nil {
+					log.Printf("Error reloading channels: %s\n", err)
+				}
+				if err := watcher.Add("channels.json"); err != nil {
+					log.Printf("channels.json watcher re-add failed: %v — restarting watcher", err)
+					return // outer loop rebuilds a fresh watcher
+				}
+			}
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return
+			}
+			log.Printf("Watcher error: %s\n", err)
+		}
+	}
+}
+
+// GetChannel returns the channel at the given zero-based index.
+// The index is a volatile slice position, not a stable ID — it changes when
+// channels.json is reloaded.
+// Safe for concurrent use alongside LoadChannels and LoadChannelsFromPl.
+func GetChannel(index int) (Channel, bool) {
+	mu.Lock()
+	defer mu.Unlock()
+	if index < 0 || index >= len(channels) {
+		return Channel{}, false
+	}
+	return channels[index], true
+}
+
+// GetChannelCount returns the number of channels without copying the slice.
+// Safe for concurrent use alongside LoadChannels and LoadChannelsFromPl.
+func GetChannelCount() int {
+	mu.Lock()
+	defer mu.Unlock()
+	return len(channels)
+}
+
+// GetChannels returns a snapshot of all channels.
+// Safe for concurrent use alongside LoadChannels and LoadChannelsFromPl.
+func GetChannels() []Channel {
+	mu.Lock()
+	defer mu.Unlock()
+	result := make([]Channel, len(channels))
+	copy(result, channels)
+	return result
 }
 
 func LoadChannels() error {
-    file, err := os.Open("channels.json")
-    if err != nil {
-        return err
-    }
-    defer file.Close()
+	return loadChannelsFromFile("channels.json")
+}
 
-    var channels []Channel
-    decoder := json.NewDecoder(file)
-    err = decoder.Decode(&channels)
-    if err != nil {
-        return err
-    }
+func loadChannelsFromFile(path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
 
-    mu.Lock()
-    Channels = channels
-    mu.Unlock()
+	var chs []Channel
+	if err := json.NewDecoder(file).Decode(&chs); err != nil {
+		return err
+	}
 
-    log.Println("Channels reloaded successfully")
-    return nil
+	if len(chs) == 0 {
+		return errors.New("channels.json decoded to empty list — keeping previous channels")
+	}
+
+	SetChannels(chs)
+	log.Println("Channels reloaded successfully")
+	return nil
 }
 
 func init() {
@@ -121,18 +203,23 @@ func init() {
 
 	var playlist = os.Getenv("PLAYLIST")
 	if len(playlist) > 0 {
-	    err := LoadChannelsFromPl(playlist)	
-	    if err == nil {
+		err := LoadChannelsFromPl(playlist)
+		if err == nil {
 			return
 		} else {
-		    log.Printf("Provided m3u playlist error: %s\n",err)
+			log.Printf("Provided m3u playlist error: %s\n", err)
 		}
 	}
 
 	err := LoadChannels()
-    if err != nil {
-        log.Fatal(err)
-    }
+	if err != nil {
+		// Fatal here is intentional: with no channels the server cannot serve
+		// anything. Contrast with watcher reloads (runWatchLoop) where a failed
+		// reload keeps the previous channel list and logs an error — acceptable
+		// because the previous list is still valid. At startup there is no
+		// previous list to fall back to.
+		log.Fatal(err)
+	}
 
-    go WatchChannelsFile()
+	go WatchChannelsFile()
 }

--- a/config/channels_test.go
+++ b/config/channels_test.go
@@ -1,0 +1,227 @@
+package config
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+func TestGetChannelValidIndex(t *testing.T) {
+	t.Cleanup(func() { channels = nil })
+	channels = []Channel{{Name: "ch1", URL: "http://a.com"}, {Name: "ch2", URL: "http://b.com"}}
+
+	ch, ok := GetChannel(0)
+	if !ok {
+		t.Fatal("expected ok=true for index 0")
+	}
+	if ch.Name != "ch1" {
+		t.Errorf("expected ch1, got %s", ch.Name)
+	}
+
+	ch, ok = GetChannel(1)
+	if !ok {
+		t.Fatal("expected ok=true for index 1")
+	}
+	if ch.Name != "ch2" {
+		t.Errorf("expected ch2, got %s", ch.Name)
+	}
+}
+
+func TestGetChannelInvalidIndex(t *testing.T) {
+	t.Cleanup(func() { channels = nil })
+	channels = []Channel{{Name: "ch1", URL: "http://a.com"}}
+
+	for _, id := range []int{-1, 1, 99} {
+		_, ok := GetChannel(id)
+		if ok {
+			t.Errorf("index %d: expected ok=false, got true", id)
+		}
+	}
+}
+
+func TestGetChannelsSnapshot(t *testing.T) {
+	t.Cleanup(func() { channels = nil })
+	channels = []Channel{{Name: "original", URL: "http://a.com"}}
+
+	snapshot := GetChannels()
+	if len(snapshot) != 1 || snapshot[0].Name != "original" {
+		t.Fatal("snapshot does not match Channels")
+	}
+
+	// Mutating the snapshot must not affect internal state
+	snapshot[0].Name = "mutated"
+	ch, _ := GetChannel(0)
+	if ch.Name != "original" {
+		t.Error("mutating GetChannels() snapshot modified internal Channels state")
+	}
+}
+
+func TestGetChannelCount(t *testing.T) {
+	t.Cleanup(func() { channels = nil })
+
+	channels = []Channel{}
+	if n := GetChannelCount(); n != 0 {
+		t.Errorf("empty: expected 0, got %d", n)
+	}
+
+	channels = []Channel{{Name: "a", URL: "http://a.com"}, {Name: "b", URL: "http://b.com"}}
+	if n := GetChannelCount(); n != 2 {
+		t.Errorf("two channels: expected 2, got %d", n)
+	}
+}
+
+// TestLoadChannelsFromFile verifies the core file-load path with a temp file,
+// covering both successful decode and correct mutex-protected assignment.
+func TestLoadChannelsFromFile(t *testing.T) {
+	t.Cleanup(func() { channels = nil })
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "channels.json")
+	content := `[{"name":"ch1","url":"http://a.com"},{"name":"ch2","url":"http://b.com"}]`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := loadChannelsFromFile(path); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if n := GetChannelCount(); n != 2 {
+		t.Fatalf("expected 2 channels, got %d", n)
+	}
+	ch, ok := GetChannel(0)
+	if !ok || ch.Name != "ch1" {
+		t.Errorf("expected ch1, got %+v", ch)
+	}
+}
+
+// TestLoadChannelsFromFileEmptyRejectsAndKeepsPrevious verifies that decoding
+// an empty JSON array ([]) or null does not wipe the live channel list.
+// LoadChannelsFromPl has this guard; this test ensures loadChannelsFromFile
+// is consistent.
+func TestLoadChannelsFromFileEmptyRejectsAndKeepsPrevious(t *testing.T) {
+	channels = []Channel{{Name: "before", URL: "http://a.com"}}
+	t.Cleanup(func() { channels = nil })
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "channels.json")
+
+	for _, content := range []string{"[]", "null"} {
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := loadChannelsFromFile(path); err == nil {
+			t.Errorf("content %q: expected error, got nil — empty decode should not wipe channels", content)
+		}
+		ch, ok := GetChannel(0)
+		if !ok || ch.Name != "before" {
+			t.Errorf("content %q: channels modified after empty-decode error: got %+v", content, ch)
+		}
+	}
+}
+
+// TestRunWatchLoopAtomicSave verifies that renaming a temp file over channels.json
+// (the standard atomic-save pattern used by editors and deployment tooling) triggers
+// a reload. Previously the Remove/Rename branch only re-added the watch without
+// calling reload(), so atomic saves silently did nothing.
+func TestRunWatchLoopAtomicSave(t *testing.T) {
+	dir := t.TempDir()
+	channelsFile := filepath.Join(dir, "channels.json")
+
+	if err := os.WriteFile(channelsFile, []byte(`[]`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { watcher.Close() })
+
+	if err := watcher.Add(channelsFile); err != nil {
+		t.Fatal(err)
+	}
+
+	reloaded := make(chan struct{}, 3)
+	go runWatchLoop(watcher, func() error {
+		reloaded <- struct{}{}
+		return nil
+	})
+
+	// Atomic save: write to a temp file, rename it over the watched file.
+	tmp := channelsFile + ".tmp"
+	if err := os.WriteFile(tmp, []byte(`[{"name":"new","url":"http://b.com"}]`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(tmp, channelsFile); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-reloaded:
+		// atomic save triggered a reload — fix is working
+	case <-time.After(3 * time.Second):
+		t.Error("atomic save (rename-into-place) did not trigger a reload within 3s")
+	}
+}
+
+// TestLoadChannelsFromPlErrorLeavesChannelsUnchanged verifies that when
+// LoadChannelsFromPl fails (unreachable URL), it does not partially modify
+// Channels. Previously the function appended to the global slice without
+// holding mu, which could leave Channels in a partially-written state.
+func TestLoadChannelsFromPlErrorLeavesChannelsUnchanged(t *testing.T) {
+	t.Cleanup(func() { channels = nil })
+	channels = []Channel{{Name: "before", URL: "http://a.com"}}
+
+	// Serve an empty M3U — parser connects (no fatal) but gets 0 streams → error path.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "#EXTM3U")
+	}))
+	defer ts.Close()
+
+	err := LoadChannelsFromPl(ts.URL)
+	if err == nil {
+		t.Skip("expected error for empty playlist — skipping if parser succeeded somehow")
+	}
+
+	ch, ok := GetChannel(0)
+	if !ok || ch.Name != "before" {
+		t.Errorf("LoadChannelsFromPl error modified Channels unexpectedly: got %+v", ch)
+	}
+}
+
+// TestGetChannelConcurrentAccess verifies GetChannel is safe to call
+// concurrently alongside hot-reload writes to Channels (as done by both
+// LoadChannels and LoadChannelsFromPl).
+// Run with: go test -race ./config/...
+func TestGetChannelConcurrentAccess(t *testing.T) {
+	t.Cleanup(func() { channels = nil })
+	channels = []Channel{{Name: "test", URL: "http://example.com"}}
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 300; i++ {
+			SetChannels([]Channel{{Name: "test", URL: "http://example.com"}})
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 300; i++ {
+			GetChannel(0)
+		}
+	}()
+
+	wg.Wait()
+}

--- a/routes/discover.go
+++ b/routes/discover.go
@@ -25,7 +25,7 @@ func Discover(c *gin.Context) {
 	var host = c.Request.Host
 
 	// Defaults to channel count * 3
-	var tunerCount = len(config.Channels) * 3
+	var tunerCount = config.GetChannelCount() * 3
 	if config.Cfg.TunerCount != nil {
 		tunerCount = *config.Cfg.TunerCount
 	}

--- a/routes/discover_test.go
+++ b/routes/discover_test.go
@@ -17,7 +17,8 @@ func TestDiscoverDeviceIDStability(t *testing.T) {
 	config.Cfg.Name = "Test Tuner"
 
 	// Initialize empty channels to avoid nil pointer
-	config.Channels = []config.Channel{}
+	t.Cleanup(func() { config.SetChannels(nil) })
+	config.SetChannels([]config.Channel{})
 
 	// Create a test router
 	gin.SetMode(gin.TestMode)
@@ -64,7 +65,8 @@ func TestDiscoverResponse(t *testing.T) {
 	testName := "Amazing Tuner"
 	config.Cfg.DeviceID = &testDeviceID
 	config.Cfg.Name = testName
-	config.Channels = []config.Channel{}
+	t.Cleanup(func() { config.SetChannels(nil) })
+	config.SetChannels([]config.Channel{})
 
 	// Create a test router
 	gin.SetMode(gin.TestMode)
@@ -121,37 +123,38 @@ func TestDiscoverTunerCount(t *testing.T) {
 	config.Cfg.Name = "Test"
 
 	tests := []struct {
-		name              string
-		channels          int
-		configTunerCount  *int
+		name               string
+		channels           int
+		configTunerCount   *int
 		expectedTunerCount int
 	}{
 		{
-			name:              "Default tuner count (3x channels)",
-			channels:          5,
-			configTunerCount:  nil,
+			name:               "Default tuner count (3x channels)",
+			channels:           5,
+			configTunerCount:   nil,
 			expectedTunerCount: 15,
 		},
 		{
-			name:              "Custom tuner count",
-			channels:          5,
-			configTunerCount:  intPtr(8),
+			name:               "Custom tuner count",
+			channels:           5,
+			configTunerCount:   intPtr(8),
 			expectedTunerCount: 8,
 		},
 		{
-			name:              "No channels with custom tuner count",
-			channels:          0,
-			configTunerCount:  intPtr(3),
+			name:               "No channels with custom tuner count",
+			channels:           0,
+			configTunerCount:   intPtr(3),
 			expectedTunerCount: 3,
 		},
 	}
 
+	t.Cleanup(func() { config.SetChannels(nil) })
 	gin.SetMode(gin.TestMode)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set up channels
-			config.Channels = make([]config.Channel, tt.channels)
+			config.SetChannels(make([]config.Channel, tt.channels))
 			config.Cfg.TunerCount = tt.configTunerCount
 
 			router := gin.New()

--- a/routes/lineup.go
+++ b/routes/lineup.go
@@ -20,7 +20,7 @@ func Lineup(c *gin.Context) {
 
 	var host = c.Request.Host
 
-	for index, channel := range config.Channels {
+	for index, channel := range config.GetChannels() {
 		channelLineups = append(
 			channelLineups,
 			ChannelLineup{
@@ -42,7 +42,7 @@ type Status struct {
 	ScanInProgress int      `json:"ScanInProgress"`
 	ScanPossible   int      `json:"ScanPossible"`
 	Source         string   `json:"Source"`
-	SourceList     []string `json:"Cable"`
+	SourceList     []string `json:"SourceList"`
 }
 
 func LineupStatus(c *gin.Context) {

--- a/routes/lineup_test.go
+++ b/routes/lineup_test.go
@@ -1,0 +1,80 @@
+package routes
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/duncanleo/plex-dvr-hls/config"
+	"github.com/gin-gonic/gin"
+)
+
+// TestLineupReturnsChannels verifies Lineup builds one entry per channel with
+// correct GuideNumber, GuideName, and stream URL.
+func TestLineupReturnsChannels(t *testing.T) {
+	t.Cleanup(func() { config.SetChannels(nil) })
+	config.SetChannels([]config.Channel{
+		{Name: "Channel 1", URL: "http://stream1.com"},
+		{Name: "Channel 2", URL: "http://stream2.com"},
+	})
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/lineup.json", Lineup)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/lineup.json", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var lineups []ChannelLineup
+	if err := json.Unmarshal(w.Body.Bytes(), &lineups); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if len(lineups) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(lineups))
+	}
+	if lineups[0].GuideNumber != "1" || lineups[0].GuideName != "Channel 1" {
+		t.Errorf("entry 0: got %+v", lineups[0])
+	}
+	if lineups[1].GuideNumber != "2" || lineups[1].GuideName != "Channel 2" {
+		t.Errorf("entry 1: got %+v", lineups[1])
+	}
+}
+
+// TestLineupStatusSourceListJSON verifies the SourceList field marshals with
+// the correct JSON key "SourceList". Previously tagged json:"Cable" which caused
+// Plex to receive the wrong key name.
+func TestLineupStatusSourceListJSON(t *testing.T) {
+	status := Status{
+		ScanInProgress: 0,
+		ScanPossible:   1,
+		Source:         "Cable",
+		SourceList:     []string{"Cable"},
+	}
+	data, err := json.Marshal(status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := m["SourceList"]; !ok {
+		t.Errorf(`JSON key is %q instead of "SourceList"`, keyIn(m))
+	}
+}
+
+func keyIn(m map[string]interface{}) string {
+	for k := range m {
+		if k != "ScanInProgress" && k != "ScanPossible" && k != "Source" {
+			return k
+		}
+	}
+	return "(none)"
+}

--- a/routes/stream.go
+++ b/routes/stream.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log"
@@ -9,223 +10,240 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/duncanleo/plex-dvr-hls/config"
 	"github.com/gin-gonic/gin"
 )
 
-func Stream(c *gin.Context) {
-	var channelIDStr = c.Param("channelID")
-	channelID, err := strconv.Atoi(channelIDStr)
-	if err != nil {
-		c.Status(http.StatusBadRequest)
-		return
+// execCommandContext is the exec.CommandContext constructor. Tests override this
+// to inject a fake ffmpeg process without modifying PATH.
+var execCommandContext func(ctx context.Context, name string, arg ...string) *exec.Cmd = exec.CommandContext
+
+// streamMaxFailures, streamRetryDelay, and minHealthyDuration control the
+// restart loop (fixed delay, no exponential backoff). Tests override
+// streamRetryDelay and minHealthyDuration to avoid multi-second delays.
+var (
+	streamMaxFailures  = 3
+	streamRetryDelay   = 2 * time.Second
+	minHealthyDuration = 10 * time.Second
+)
+
+// flushWriter wraps gin.ResponseWriter to flush after each Write, ensuring
+// MPEG-TS chunks reach the client without waiting for Go's write buffer to fill.
+type flushWriter struct {
+	gin.ResponseWriter
+}
+
+func (fw flushWriter) Write(p []byte) (int, error) {
+	n, err := fw.ResponseWriter.Write(p)
+	if err == nil {
+		fw.ResponseWriter.Flush()
 	}
+	return n, err
+}
 
-	var channel = config.Channels[channelID-1]
-	var transcode = c.Query("transcode")
-
-	log.Printf("[STREAM] Starting '%s'\n", channel.Name)
-
-	c.Header("Content-Type", "video/mp2t")
-
-	var ffmpegArgs []string
+func buildFFmpegArgs(channel config.Channel, transcode string) []string {
+	var args []string
 
 	if channel.ProxyConfig != nil {
-		ffmpegArgs = append(
-			ffmpegArgs,
+		args = append(args,
 			"-http_proxy",
 			fmt.Sprintf("http://%s:%s@%s", channel.ProxyConfig.Username, channel.ProxyConfig.Password, channel.ProxyConfig.Host),
 		)
 	}
 
+	// ffmpeg -headers takes a single dict; multiple -headers flags overwrite each other.
+	// Build one combined value so both UserAgent and Referer reach the origin.
+	var headers string
 	if channel.UserAgent != nil {
-		ffmpegArgs = append(
-			ffmpegArgs,
-			"-headers",
-			fmt.Sprintf("User-Agent: %s", *channel.UserAgent),
-		)
+		headers += fmt.Sprintf("User-Agent: %s\r\n", *channel.UserAgent)
 	}
-
 	if channel.Referer != nil {
-		ffmpegArgs = append(
-			ffmpegArgs,
-			"-headers",
-			fmt.Sprintf("Referer: %s", *channel.Referer),
-		)
+		headers += fmt.Sprintf("Referer: %s\r\n", *channel.Referer)
+	}
+	if headers != "" {
+		args = append(args, "-headers", headers)
 	}
 
 	switch config.Cfg.GetEncoderProfile() {
 	case config.EncoderProfileVAAPI:
-		ffmpegArgs = append(
-			ffmpegArgs,
-			"-vaapi_device",
-			"/dev/dri/renderD128",
-			"-hwaccel",
-			"vaapi",
-			"-hwaccel_output_format",
-			"vaapi",
+		args = append(args,
+			"-vaapi_device", "/dev/dri/renderD128",
+			"-hwaccel", "vaapi",
+			"-hwaccel_output_format", "vaapi",
 		)
 	case config.EncoderProfileVideoToolbox:
-		ffmpegArgs = append(
-			ffmpegArgs,
-			"-hwaccel",
-			"videotoolbox",
-		)
+		args = append(args, "-hwaccel", "videotoolbox")
 	case config.EncoderProfileNVENC:
-		ffmpegArgs = append(
-			ffmpegArgs,
-			"-hwaccel",
-			"cuda",
-			"-hwaccel_output_format",
-			"cuda",
+		args = append(args,
+			"-hwaccel", "cuda",
+			"-hwaccel_output_format", "cuda",
 		)
 	}
 
-	ffmpegArgs = append(
-		ffmpegArgs,
-		"-i",
-		channel.URL,
-	)
+	// -reconnect* flags are HTTP(S)-only; passing them to RTSP or other
+	// protocols causes ffmpeg to error on startup.
+	if strings.HasPrefix(channel.URL, "http://") || strings.HasPrefix(channel.URL, "https://") {
+		args = append(args,
+			"-reconnect", "1",
+			"-reconnect_at_eof", "1",
+			"-reconnect_streamed", "1",
+			"-reconnect_delay_max", "5",
+		)
+	}
+
+	args = append(args, "-i", channel.URL)
 
 	if channel.DisableTranscode {
-		ffmpegArgs = append(
-			ffmpegArgs,
-			"-c:v",
-			"copy",
-		)
+		args = append(args, "-c:v", "copy")
 	} else {
 		switch config.Cfg.GetEncoderProfile() {
 		case config.EncoderProfileVideoToolbox:
-			ffmpegArgs = append(
-				ffmpegArgs,
-				"-c:v",
-				"h264_videotoolbox",
-			)
-			break
+			args = append(args, "-c:v", "h264_videotoolbox")
 		case config.EncoderProfileVAAPI:
-			ffmpegArgs = append(
-				ffmpegArgs,
-				"-c:v",
-				"h264_vaapi",
-				"-vf",
-				"scale_vaapi=format=nv12,hwupload",
-			)
-			break
+			args = append(args, "-c:v", "h264_vaapi", "-vf", "scale_vaapi=format=nv12,hwupload")
 		case config.EncoderProfileOMX:
-			ffmpegArgs = append(
-				ffmpegArgs,
-				"-c:v",
-				"h264_omx",
-			)
-			break
+			args = append(args, "-c:v", "h264_omx")
 		case config.EncoderProfileNVENC:
-			ffmpegArgs = append(
-				ffmpegArgs,
-				"-c:v",
-				"h264_nvenc",
-				"-preset",
-				"p3",
-			)
-			break
+			args = append(args, "-c:v", "h264_nvenc", "-preset", "p3")
 		default:
-			ffmpegArgs = append(
-				ffmpegArgs,
-				"-c:v",
-				"libx264",
-				"-preset",
-				"superfast",
-			)
-			break
+			args = append(args, "-c:v", "libx264", "-preset", "superfast")
 		}
 	}
 
-	ffmpegArgs = append(
-		ffmpegArgs,
-		"-b:a",
-		"256k",
+	if channel.DisableAudioTranscode {
+		args = append(args, "-c:a", "copy")
+	} else {
+		args = append(args, "-b:a", "256k")
+	}
+
+	args = append(args,
 		"-copyinkf",
-		"-metadata",
-		"service_provider=AMAZING",
-		"-metadata",
-		fmt.Sprintf("service_name=%s", strings.ReplaceAll(channel.Name, " ", "")),
-		"-tune",
-		"zerolatency",
-		"-mbd",
-		"rd",
-		"-flags",
-		"+ilme+ildct",
-		"-fflags",
-		"+genpts",
+		"-metadata", "service_provider=AMAZING",
+		"-metadata", fmt.Sprintf("service_name=%s", strings.ReplaceAll(channel.Name, " ", "")),
+		"-tune", "zerolatency",
+		"-mbd", "rd",
+		"-flags", "+ilme+ildct",
+		"-fflags", "+genpts",
 	)
 
 	switch transcode {
-	case "mobile":
-	case "internet720":
-		ffmpegArgs = append(
-			ffmpegArgs,
-			"-s",
-			"1280x720",
-			"-r",
-			"30",
-		)
-		break
+	case "mobile", "internet720":
+		args = append(args, "-s", "1280x720", "-r", "30")
 	}
 
-	ffmpegArgs = append(
-		ffmpegArgs,
-		"-f",
-		"mpegts",
-		"pipe:1",
-	)
+	args = append(args, "-f", "mpegts", "pipe:1")
 
-	var ffmpegProcess = exec.Command(
-		"ffmpeg",
-		ffmpegArgs...,
-	)
+	return args
+}
 
-	outPipe, err := ffmpegProcess.StdoutPipe()
-	if err != nil {
-		log.Println(err)
-		c.Status(http.StatusInternalServerError)
-		return
-	}
-
-	ffmpegProcess.Stderr = os.Stdout
-
-	err = ffmpegProcess.Start()
-	if err != nil {
-		log.Println(err)
-		c.Status(http.StatusInternalServerError)
-		return
-	}
-
-	// Detect errors on the FFMPEG side. Terminate the stream if any.
-	go func() {
-		err = ffmpegProcess.Wait()
+// StreamWithContext returns a handler that streams the channel's video.
+// serverCtx is cancelled on SIGTERM so in-flight ffmpeg processes are killed
+// cleanly on shutdown rather than orphaned.
+func StreamWithContext(serverCtx context.Context) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		channelID, err := strconv.Atoi(c.Param("channelID"))
 		if err != nil {
-			log.Println(err)
-			c.Status(http.StatusInternalServerError)
+			c.AbortWithStatus(http.StatusBadRequest)
 			return
 		}
-	}()
 
-	c.Stream(func(w io.Writer) bool {
-		_, err := io.Copy(w, outPipe)
-
-		if err != nil {
-			log.Println(err)
-			return false
+		channel, ok := config.GetChannel(channelID - 1)
+		if !ok {
+			c.AbortWithStatus(http.StatusNotFound)
+			return
 		}
 
-		if ffmpegProcess.Process != nil {
-			ffmpegProcess.Process.Kill()
-		}
-		return true
-	})
+		transcode := c.Query("transcode")
+		log.Printf("[STREAM] Starting '%s'\n", channel.Name)
+		c.Header("Content-Type", "video/mp2t")
 
-	// Ensure that the FFMPEG process is ended once it is not needed.
-	if ffmpegProcess.Process != nil {
-		ffmpegProcess.Process.Kill()
+		// ctx is cancelled when either the client disconnects or the server shuts down.
+		ctx, cancel := context.WithCancel(serverCtx)
+		defer cancel()
+		go func() {
+			<-c.Request.Context().Done()
+			cancel()
+		}()
+
+		args := buildFFmpegArgs(channel, transcode)
+		quickRestarts := 0
+		var totalWritten int64
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			startTime := time.Now()
+			ffmpegProcess := execCommandContext(ctx, "ffmpeg", args...)
+
+			outPipe, pipeErr := ffmpegProcess.StdoutPipe()
+			if pipeErr != nil {
+				log.Printf("[STREAM] pipe error for '%s': %v\n", channel.Name, pipeErr)
+				if totalWritten == 0 {
+					c.AbortWithStatus(http.StatusInternalServerError)
+				}
+				return
+			}
+			ffmpegProcess.Stderr = os.Stdout
+
+			if startErr := ffmpegProcess.Start(); startErr != nil {
+				log.Printf("[STREAM] ffmpeg failed to start for '%s': %v\n", channel.Name, startErr)
+				if totalWritten == 0 {
+					c.AbortWithStatus(http.StatusInternalServerError)
+				}
+				return
+			}
+
+			n, copyErr := io.Copy(flushWriter{c.Writer}, outPipe)
+			totalWritten += n
+
+			if waitErr := ffmpegProcess.Wait(); waitErr != nil {
+				log.Printf("[STREAM] ffmpeg exited for '%s': %v\n", channel.Name, waitErr)
+			}
+
+			// Check context cancellation first: a killed ffmpeg gives copyErr==nil
+			// (pipe closes cleanly), so checking copyErr alone misses this case.
+			if ctx.Err() != nil {
+				log.Printf("[STREAM] stream for '%s' stopped (%v) after %d bytes\n", channel.Name, ctx.Err(), totalWritten)
+				return
+			}
+
+			if copyErr != nil {
+				log.Printf("[STREAM] copy error for '%s' after %d bytes: %v\n", channel.Name, totalWritten, copyErr)
+				return
+			}
+
+			// Count any short-lived exit (0-byte or bytes-then-die) as a quick
+			// restart. Only a run that lasted minHealthyDuration resets the counter,
+			// preventing alternating 0-byte / trivial-byte patterns from bypassing
+			// the cap.
+			if time.Since(startTime) < minHealthyDuration {
+				quickRestarts++
+				if quickRestarts >= streamMaxFailures {
+					log.Printf("[STREAM] ffmpeg exited quickly %d times for '%s', giving up\n",
+						streamMaxFailures, channel.Name)
+					if totalWritten == 0 {
+						c.AbortWithStatus(http.StatusBadGateway)
+					}
+					return
+				}
+				log.Printf("[STREAM] ffmpeg exited quickly for '%s' (restart %d/%d), retrying in %v\n",
+					channel.Name, quickRestarts, streamMaxFailures, streamRetryDelay)
+			} else {
+				quickRestarts = 0
+				log.Printf("[STREAM] Restarting ffmpeg for '%s'\n", channel.Name)
+			}
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(streamRetryDelay):
+			}
+		}
 	}
 }

--- a/routes/stream_test.go
+++ b/routes/stream_test.go
@@ -1,0 +1,657 @@
+package routes
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/duncanleo/plex-dvr-hls/config"
+	"github.com/gin-gonic/gin"
+)
+
+// fakeExecCommand returns a no-op OS command that exits immediately with zero
+// stdout bytes, simulating an ffmpeg process that fails to produce any output.
+func fakeExecCommand(ctx context.Context, name string, arg ...string) *exec.Cmd {
+	if runtime.GOOS == "windows" {
+		return exec.CommandContext(ctx, "cmd", "/c", "exit")
+	}
+	return exec.CommandContext(ctx, "sh", "-c", "exit")
+}
+
+// TestStreamPipeEOFReturnsNilError documents that io.Copy on a closed pipe
+// returns nil — not io.EOF. This is why the stream retry loop treats n==0 as
+// a failure signal: a clean ffmpeg exit (no output written) is indistinguishable
+// from a successful-but-empty read via the error value alone.
+func TestStreamPipeEOFReturnsNilError(t *testing.T) {
+	pr, pw := io.Pipe()
+	pw.Close()
+
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, pr)
+	if err != nil {
+		t.Errorf("io.Copy on closed pipe: expected nil, got %v", err)
+	}
+}
+
+// TestStreamHandlerBadRequest verifies Stream returns 400 for a non-numeric channel ID.
+func TestStreamHandlerBadRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/stream/:channelID", StreamWithContext(context.Background()))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/stream/abc", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for non-numeric channel ID, got %d", w.Code)
+	}
+}
+
+// TestStreamHandlerNotFound verifies Stream returns 404 when the channel index
+// is out of range.
+func TestStreamHandlerNotFound(t *testing.T) {
+	t.Cleanup(func() { config.SetChannels(nil) })
+	config.SetChannels([]config.Channel{})
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/stream/:channelID", StreamWithContext(context.Background()))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/stream/99", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for unknown channel, got %d", w.Code)
+	}
+}
+
+// TestStreamRetryLoop502 verifies that when ffmpeg exits immediately without
+// writing any bytes, the handler retries streamMaxFailures times then returns 502.
+func TestStreamRetryLoop502(t *testing.T) {
+	t.Cleanup(func() { config.SetChannels(nil) })
+	config.SetChannels([]config.Channel{{Name: "test", URL: "http://example.com"}})
+
+	origCmd := execCommandContext
+	execCommandContext = fakeExecCommand
+	t.Cleanup(func() { execCommandContext = origCmd })
+
+	origDelay := streamRetryDelay
+	streamRetryDelay = 5 * time.Millisecond
+	t.Cleanup(func() { streamRetryDelay = origDelay })
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/stream/:channelID", StreamWithContext(context.Background()))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/stream/1", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("expected 502 after %d zero-byte exits, got %d", streamMaxFailures, w.Code)
+	}
+}
+
+// fakeExecCommandSlow returns a command that runs for longer than the default
+// minHealthyDuration (10s), used to verify that a healthy run resets quickRestarts.
+// Uses sleep directly (no shell wrapper) so exec.CommandContext can kill it cleanly.
+func fakeExecCommandSlow(ctx context.Context, name string, arg ...string) *exec.Cmd {
+	if runtime.GOOS == "windows" {
+		return exec.CommandContext(ctx, "powershell", "-NoProfile", "-Command", "Start-Sleep -Milliseconds 200")
+	}
+	return exec.CommandContext(ctx, "sleep", "0.2")
+}
+
+// TestStreamRetryLoopHealthyReset verifies that a run lasting longer than
+// minHealthyDuration resets quickRestarts to zero. Without the reset, a sign
+// flip on the < vs >= comparison would be undetectable by the other tests.
+func TestStreamRetryLoopHealthyReset(t *testing.T) {
+	t.Cleanup(func() { config.SetChannels(nil) })
+	config.SetChannels([]config.Channel{{Name: "test", URL: "http://example.com"}})
+
+	// Call sequence: (streamMaxFailures-1) quick → 1 healthy (reset) → streamMaxFailures quick → 502
+	// Total calls: 2 * streamMaxFailures
+	var (
+		callMu    sync.Mutex
+		callCount int
+	)
+	origCmd := execCommandContext
+	execCommandContext = func(ctx context.Context, name string, arg ...string) *exec.Cmd {
+		callMu.Lock()
+		n := callCount
+		callCount++
+		callMu.Unlock()
+		if n == streamMaxFailures-1 {
+			return fakeExecCommandSlow(ctx, name, arg...)
+		}
+		return fakeExecCommand(ctx, name, arg...)
+	}
+	t.Cleanup(func() { execCommandContext = origCmd })
+
+	origDelay := streamRetryDelay
+	streamRetryDelay = 5 * time.Millisecond
+	t.Cleanup(func() { streamRetryDelay = origDelay })
+
+	origMin := minHealthyDuration
+	minHealthyDuration = 100 * time.Millisecond
+	t.Cleanup(func() { minHealthyDuration = origMin })
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/stream/:channelID", StreamWithContext(context.Background()))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/stream/1", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("expected 502 after reset+cap cycle, got %d", w.Code)
+	}
+	callMu.Lock()
+	total := callCount
+	callMu.Unlock()
+	expected := 2 * streamMaxFailures
+	if total != expected {
+		t.Errorf("expected %d total calls (%d quick + 1 healthy reset + %d quick), got %d — healthy-run reset may not be working",
+			expected, streamMaxFailures-1, streamMaxFailures, total)
+	}
+}
+
+// TestStreamStartFailureReturns500 verifies that when ffmpeg fails to start
+// (e.g. binary not found), the handler returns 500 and does not retry.
+func TestStreamStartFailureReturns500(t *testing.T) {
+	t.Cleanup(func() { config.SetChannels(nil) })
+	config.SetChannels([]config.Channel{{Name: "test", URL: "http://example.com"}})
+
+	origCmd := execCommandContext
+	execCommandContext = func(ctx context.Context, name string, arg ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "nonexistent-binary-that-does-not-exist-xyz")
+	}
+	t.Cleanup(func() { execCommandContext = origCmd })
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/stream/:channelID", StreamWithContext(context.Background()))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/stream/1", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500 on ffmpeg start failure, got %d", w.Code)
+	}
+}
+
+// TestBuildFFmpegArgsEncoderProfiles verifies each hwaccel profile produces
+// the correct pre-input and codec args.
+func TestBuildFFmpegArgsEncoderProfiles(t *testing.T) {
+	channel := config.Channel{Name: "test", URL: "http://example.com"}
+
+	tests := []struct {
+		profile      config.EncoderProfile
+		wantPreInput []string
+		wantCodec    string
+	}{
+		{
+			profile:      config.EncoderProfileCPU,
+			wantPreInput: nil,
+			wantCodec:    "libx264",
+		},
+		{
+			profile:      config.EncoderProfileVAAPI,
+			wantPreInput: []string{"-vaapi_device", "-hwaccel", "vaapi", "-hwaccel_output_format"},
+			wantCodec:    "h264_vaapi",
+		},
+		{
+			profile:      config.EncoderProfileVideoToolbox,
+			wantPreInput: []string{"-hwaccel", "videotoolbox"},
+			wantCodec:    "h264_videotoolbox",
+		},
+		{
+			profile:      config.EncoderProfileNVENC,
+			wantPreInput: []string{"-hwaccel", "cuda", "-hwaccel_output_format"},
+			wantCodec:    "h264_nvenc",
+		},
+		{
+			profile:      config.EncoderProfileOMX,
+			wantPreInput: nil,
+			wantCodec:    "h264_omx",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.profile), func(t *testing.T) {
+			config.Cfg.EncoderProfile = &tt.profile
+			defer func() { config.Cfg.EncoderProfile = nil }()
+
+			args := buildFFmpegArgs(channel, "")
+			iIdx := findInputIdx(args)
+			if iIdx == -1 {
+				t.Fatalf("profile %s: -i flag not found in args", tt.profile)
+			}
+
+			for _, flag := range tt.wantPreInput {
+				if !contains(args[:iIdx], flag) {
+					t.Errorf("profile %s: expected arg %q before -i", tt.profile, flag)
+				}
+			}
+			if !contains(args[iIdx:], tt.wantCodec) {
+				t.Errorf("profile %s: expected codec %q after -i", tt.profile, tt.wantCodec)
+			}
+		})
+	}
+}
+
+// TestBuildFFmpegArgsDisableTranscode verifies that disableTranscode uses
+// -c:v copy instead of a software/hardware encoder.
+func TestBuildFFmpegArgsDisableTranscode(t *testing.T) {
+	channel := config.Channel{Name: "test", URL: "http://example.com", DisableTranscode: true}
+	args := buildFFmpegArgs(channel, "")
+	iIdx := findInputIdx(args)
+	if iIdx == -1 {
+		t.Fatal("-i flag not found in args")
+	}
+	postInput := args[iIdx:]
+
+	if !contains(postInput, "copy") {
+		t.Error("disableTranscode: expected -c:v copy after -i")
+	}
+	for _, enc := range []string{"libx264", "h264_vaapi", "h264_nvenc", "h264_videotoolbox", "h264_omx"} {
+		if contains(args, enc) {
+			t.Errorf("disableTranscode: unexpected encoder %q", enc)
+		}
+	}
+}
+
+// TestBuildFFmpegArgsHeaders verifies UserAgent and Referer are combined into
+// a single -headers value so neither overwrites the other in ffmpeg's header dict.
+func TestBuildFFmpegArgsHeaders(t *testing.T) {
+	ua := "TestAgent/1.0"
+	ref := "https://example.com"
+	channel := config.Channel{
+		Name:      "test",
+		URL:       "http://example.com",
+		UserAgent: &ua,
+		Referer:   &ref,
+	}
+	args := buildFFmpegArgs(channel, "")
+	iIdx := findInputIdx(args)
+	if iIdx == -1 {
+		t.Fatal("-i flag not found in args")
+	}
+	preInput := args[:iIdx]
+
+	// Count -headers occurrences before -i — must be exactly one combined value.
+	headerCount := 0
+	combinedValue := ""
+	for i, a := range preInput {
+		if a == "-headers" && i+1 < len(preInput) {
+			headerCount++
+			combinedValue = preInput[i+1]
+		}
+	}
+	if headerCount != 1 {
+		t.Errorf("expected exactly 1 -headers flag before -i, got %d (second would silently overwrite the first)", headerCount)
+	}
+	if !strings.Contains(combinedValue, "User-Agent: "+ua) {
+		t.Errorf("UserAgent missing from combined -headers value: %q", combinedValue)
+	}
+	if !strings.Contains(combinedValue, "Referer: "+ref) {
+		t.Errorf("Referer missing from combined -headers value: %q", combinedValue)
+	}
+}
+
+// TestBuildFFmpegArgsHeadersPartial verifies that setting only one of UserAgent
+// or Referer still produces exactly one -headers flag, and that setting neither
+// produces no -headers flag at all.
+func TestBuildFFmpegArgsHeadersPartial(t *testing.T) {
+	ua := "TestAgent/1.0"
+	ref := "https://example.com"
+
+	countHeadersBeforeI := func(args []string) int {
+		iIdx := findInputIdx(args)
+		if iIdx == -1 {
+			iIdx = len(args)
+		}
+		n := 0
+		for _, a := range args[:iIdx] {
+			if a == "-headers" {
+				n++
+			}
+		}
+		return n
+	}
+
+	// UA only
+	args := buildFFmpegArgs(config.Channel{Name: "t", URL: "http://x.com", UserAgent: &ua}, "")
+	if countHeadersBeforeI(args) != 1 {
+		t.Errorf("UA-only: expected 1 -headers flag before -i, got %d", countHeadersBeforeI(args))
+	}
+	iIdx := findInputIdx(args)
+	if iIdx == -1 {
+		t.Fatal("UA-only: -i flag not found")
+	}
+	if !contains(args[:iIdx], "User-Agent: "+ua+"\r\n") {
+		t.Errorf("UA-only: UA missing before -i")
+	}
+
+	// Referer only
+	args = buildFFmpegArgs(config.Channel{Name: "t", URL: "http://x.com", Referer: &ref}, "")
+	if countHeadersBeforeI(args) != 1 {
+		t.Errorf("Referer-only: expected 1 -headers flag before -i, got %d", countHeadersBeforeI(args))
+	}
+	iIdx = findInputIdx(args)
+	if iIdx == -1 {
+		t.Fatal("Referer-only: -i flag not found")
+	}
+	if !contains(args[:iIdx], "Referer: "+ref+"\r\n") {
+		t.Errorf("Referer-only: Referer missing before -i")
+	}
+
+	// Neither
+	args = buildFFmpegArgs(config.Channel{Name: "t", URL: "http://x.com"}, "")
+	if countHeadersBeforeI(args) != 0 {
+		t.Errorf("no headers: expected 0 -headers flags before -i, got %d", countHeadersBeforeI(args))
+	}
+}
+
+// TestBuildFFmpegArgsProxy verifies proxy config is passed as -http_proxy.
+func TestBuildFFmpegArgsProxy(t *testing.T) {
+	channel := config.Channel{
+		Name: "test",
+		URL:  "http://example.com",
+		ProxyConfig: &config.ProxyConfig{
+			Host:     "proxy.example.com:3128",
+			Username: "user",
+			Password: "pass",
+		},
+	}
+	args := buildFFmpegArgs(channel, "")
+	iIdx := findInputIdx(args)
+	if iIdx == -1 {
+		t.Fatal("-i flag not found in args")
+	}
+	preInput := args[:iIdx]
+
+	if !contains(preInput, "-http_proxy") {
+		t.Error("proxy: expected -http_proxy flag before -i")
+	}
+	if !contains(preInput, "http://user:pass@proxy.example.com:3128") {
+		t.Error("proxy: expected formatted proxy URL before -i")
+	}
+}
+
+// fakeExecCommandWriteAndExit returns a command that writes a few bytes to
+// stdout then exits — simulating an ffmpeg process that starts successfully but
+// dies almost immediately (the bytes-then-die flapping pattern).
+func fakeExecCommandWriteAndExit(ctx context.Context, name string, arg ...string) *exec.Cmd {
+	if runtime.GOOS == "windows" {
+		return exec.CommandContext(ctx, "cmd", "/c", "echo", "x")
+	}
+	return exec.CommandContext(ctx, "sh", "-c", "printf x")
+}
+
+// fakeExecCommandBlock returns a command that blocks until its context is
+// cancelled, simulating an ffmpeg process that is running a live stream.
+// On Windows, powershell Start-Sleep is used because Git Bash shadows the
+// built-in timeout.exe with its own version that rejects Windows-style flags.
+func fakeExecCommandBlock(ctx context.Context, name string, arg ...string) *exec.Cmd {
+	if runtime.GOOS == "windows" {
+		return exec.CommandContext(ctx, "powershell", "-NoProfile", "-Command", "Start-Sleep 30")
+	}
+	// Direct exec (no sh wrapper) so exec.CommandContext's SIGKILL reaches the
+	// sleep process itself — a sh grandchild would survive the kill and hold the
+	// pipe open, preventing io.Copy from returning.
+	return exec.CommandContext(ctx, "sleep", "30")
+}
+
+// TestStreamRetryLoopBytesAndDie verifies that an ffmpeg process that writes
+// bytes but exits quickly (short-lived) still accumulates toward the restart
+// cap. Previously consecutiveFailures only incremented on zero-byte exits, so
+// the 1-byte / 0-byte alternating pattern could bypass the cap entirely.
+func TestStreamRetryLoopBytesAndDie(t *testing.T) {
+	t.Cleanup(func() { config.SetChannels(nil) })
+	config.SetChannels([]config.Channel{{Name: "test", URL: "http://example.com"}})
+
+	origCmd := execCommandContext
+	execCommandContext = fakeExecCommandWriteAndExit
+	t.Cleanup(func() { execCommandContext = origCmd })
+
+	origDelay := streamRetryDelay
+	streamRetryDelay = 5 * time.Millisecond
+	t.Cleanup(func() { streamRetryDelay = origDelay })
+	// minHealthyDuration left at default (10s): any sub-second process is "quick".
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/stream/:channelID", StreamWithContext(context.Background()))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/stream/1", nil)
+
+	// Once bytes are written the response is already 200, so we can't assert 502.
+	// What matters is that the handler returns (cap fired) rather than looping forever.
+	done := make(chan struct{})
+	go func() {
+		router.ServeHTTP(w, req)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Errorf("handler did not return after %d short-lived exits — bytes-then-die pattern bypasses cap", streamMaxFailures)
+	}
+	if w.Body.Len() == 0 {
+		t.Error("expected bytes in response body before handler gave up")
+	}
+}
+
+// TestStreamContextCancellationKillsFFmpeg verifies that cancelling the
+// request context (client disconnect or server shutdown) causes the handler
+// to return promptly even while ffmpeg is blocking on output.
+func TestStreamContextCancellationKillsFFmpeg(t *testing.T) {
+	t.Cleanup(func() { config.SetChannels(nil) })
+	config.SetChannels([]config.Channel{{Name: "test", URL: "http://example.com"}})
+
+	origCmd := execCommandContext
+	execCommandContext = fakeExecCommandBlock
+	t.Cleanup(func() { execCommandContext = origCmd })
+
+	origDelay := streamRetryDelay
+	streamRetryDelay = 5 * time.Millisecond
+	t.Cleanup(func() { streamRetryDelay = origDelay })
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/stream/:channelID", StreamWithContext(context.Background()))
+
+	w := httptest.NewRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/stream/1", nil)
+
+	done := make(chan struct{})
+	go func() {
+		router.ServeHTTP(w, req)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Error("handler did not exit within 2s after context cancellation")
+		<-done // wait for goroutine to finish before t.Cleanup mutates execCommandContext
+	}
+}
+
+// TestStreamServerCtxCancellationKillsFFmpeg verifies that cancelling the
+// serverCtx (SIGTERM path in main.go) kills in-flight streams. Unlike the
+// client-disconnect test above, this uses a non-cancelled request context so
+// only the server-side path is exercised.
+func TestStreamServerCtxCancellationKillsFFmpeg(t *testing.T) {
+	t.Cleanup(func() { config.SetChannels(nil) })
+	config.SetChannels([]config.Channel{{Name: "test", URL: "http://example.com"}})
+
+	origCmd := execCommandContext
+	execCommandContext = fakeExecCommandBlock
+	t.Cleanup(func() { execCommandContext = origCmd })
+
+	origDelay := streamRetryDelay
+	streamRetryDelay = 5 * time.Millisecond
+	t.Cleanup(func() { streamRetryDelay = origDelay })
+
+	gin.SetMode(gin.TestMode)
+	serverCtx, serverCancel := context.WithCancel(context.Background())
+	router := gin.New()
+	router.GET("/stream/:channelID", StreamWithContext(serverCtx))
+
+	w := httptest.NewRecorder()
+	// Request context is never cancelled — only serverCtx will be.
+	req, _ := http.NewRequest(http.MethodGet, "/stream/1", nil)
+
+	done := make(chan struct{})
+	go func() {
+		router.ServeHTTP(w, req)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	serverCancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Error("handler did not exit within 2s after server context cancellation")
+		<-done
+	}
+}
+
+func contains(args []string, target string) bool {
+	for _, a := range args {
+		if a == target {
+			return true
+		}
+	}
+	return false
+}
+
+// findInputIdx returns the index of "-i" in args, or -1 if not found.
+// Used to assert that flags appear in the correct position relative to the
+// input source: pre-input opts (proxy, headers, hwaccel) must precede -i;
+// codec/filter opts must follow it.
+func findInputIdx(args []string) int {
+	for i, a := range args {
+		if a == "-i" {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestBuildFFmpegArgsReconnect verifies that reconnect flags are present before
+// -i so ffmpeg automatically recovers from upstream HLS hiccups instead of
+// exiting and dropping the Plex stream permanently.
+func TestBuildFFmpegArgsReconnect(t *testing.T) {
+	channel := config.Channel{Name: "test", URL: "http://example.com/stream.m3u8"}
+	args := buildFFmpegArgs(channel, "")
+
+	iIdx := -1
+	for i, a := range args {
+		if a == "-i" {
+			iIdx = i
+			break
+		}
+	}
+	if iIdx == -1 {
+		t.Fatal("-i flag not found in args")
+	}
+	preInput := args[:iIdx]
+
+	for _, flag := range []string{"-reconnect", "-reconnect_at_eof", "-reconnect_streamed"} {
+		if !contains(preInput, flag) {
+			t.Errorf("reconnect flag %q missing before -i — stream will not recover from upstream drops", flag)
+		}
+	}
+}
+
+// TestBuildFFmpegArgsReconnectRTSP verifies that -reconnect* flags are NOT
+// added for non-HTTP URLs (e.g. RTSP). These flags are HTTP-only; ffmpeg
+// errors on them for other protocols, which would register as a quick-exit and
+// give up with 502 after streamMaxFailures retries.
+func TestBuildFFmpegArgsReconnectRTSP(t *testing.T) {
+	channel := config.Channel{Name: "test", URL: "rtsp://camera.local/stream"}
+	args := buildFFmpegArgs(channel, "")
+	for _, flag := range []string{"-reconnect", "-reconnect_at_eof", "-reconnect_streamed", "-reconnect_delay_max"} {
+		if contains(args, flag) {
+			t.Errorf("RTSP URL: reconnect flag %q must not be present (HTTP-only option)", flag)
+		}
+	}
+}
+
+// TestBuildFFmpegArgsAudioTranscode verifies disableAudioTranscode switches
+// from re-encoding audio at 256k to passing the source audio through unchanged.
+func TestBuildFFmpegArgsAudioTranscode(t *testing.T) {
+	reencoded := buildFFmpegArgs(config.Channel{Name: "test", URL: "http://example.com"}, "")
+	iIdx := findInputIdx(reencoded)
+	if iIdx == -1 {
+		t.Fatal("-i flag not found in args")
+	}
+	postInput := reencoded[iIdx:]
+	if !contains(postInput, "-b:a") {
+		t.Error("default: expected -b:a after -i for audio re-encoding")
+	}
+	if contains(postInput, "-c:a") {
+		t.Error("default: unexpected -c:a copy after -i")
+	}
+
+	copied := buildFFmpegArgs(config.Channel{Name: "test", URL: "http://example.com", DisableAudioTranscode: true}, "")
+	iIdx = findInputIdx(copied)
+	if iIdx == -1 {
+		t.Fatal("-i flag not found in args")
+	}
+	postInput = copied[iIdx:]
+	if contains(postInput, "-b:a") {
+		t.Error("disableAudioTranscode: unexpected -b:a after -i, audio should be copied")
+	}
+	if !contains(postInput, "-c:a") {
+		t.Error("disableAudioTranscode: expected -c:a copy after -i")
+	}
+}
+
+// TestBuildFFmpegArgsMobile verifies that both "mobile" and "internet720"
+// transcode modes apply resolution scaling. Previously "mobile" matched an
+// empty switch case and produced no scaling args while "internet720" did.
+func TestBuildFFmpegArgsMobile(t *testing.T) {
+	channel := config.Channel{Name: "test", URL: "http://example.com"}
+
+	hasScaling := func(args []string) bool {
+		for i, a := range args {
+			if a == "-s" && i+1 < len(args) && args[i+1] == "1280x720" {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !hasScaling(buildFFmpegArgs(channel, "mobile")) {
+		t.Error("mobile transcode missing -s 1280x720")
+	}
+	if !hasScaling(buildFFmpegArgs(channel, "internet720")) {
+		t.Error("internet720 transcode missing -s 1280x720")
+	}
+	if hasScaling(buildFFmpegArgs(channel, "")) {
+		t.Error("default transcode should not include -s 1280x720")
+	}
+}

--- a/routes/templates/xmltv.tmpl
+++ b/routes/templates/xmltv.tmpl
@@ -1,3 +1,4 @@
+{{- /* Test fixture — mirrors templates/xmltv.tmpl at the repo root. Keep in sync. */ -}}
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE tv SYSTEM "xmltv.dtd">
 

--- a/routes/xmltv.go
+++ b/routes/xmltv.go
@@ -2,6 +2,7 @@ package routes
 
 import (
 	"bytes"
+	_ "embed"
 	"log"
 	"net/http"
 	"text/template"
@@ -11,10 +12,13 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+//go:embed templates/xmltv.tmpl
+var xmltvTemplate string
+
 type ChannelSimplified struct {
-    ID   int
-    Name string
-    Icon *string
+	ID   int
+	Name string
+	Icon *string
 }
 
 type Programme struct {
@@ -26,7 +30,7 @@ type Programme struct {
 func XMLTV(c *gin.Context) {
 	var channels []ChannelSimplified
 
-	for index, channel := range config.Channels {
+	for index, channel := range config.GetChannels() {
 		channels = append(
 			channels,
 			ChannelSimplified{
@@ -59,10 +63,15 @@ func XMLTV(c *gin.Context) {
 		)
 	}
 
-	t := template.Must(template.New("xmltv.tmpl").ParseFiles("templates/xmltv.tmpl"))
+	t, err := template.New("xmltv.tmpl").Parse(xmltvTemplate)
+	if err != nil {
+		log.Println(err)
+		c.AbortWithStatus(http.StatusInternalServerError)
+		return
+	}
 
 	var b bytes.Buffer
-	var err = t.Execute(
+	err = t.Execute(
 		&b,
 		gin.H{
 			"channels":   channels,
@@ -72,7 +81,7 @@ func XMLTV(c *gin.Context) {
 
 	if err != nil {
 		log.Println(err)
-		c.Status(http.StatusInternalServerError)
+		c.AbortWithStatus(http.StatusInternalServerError)
 		return
 	}
 

--- a/routes/xmltv_test.go
+++ b/routes/xmltv_test.go
@@ -1,0 +1,39 @@
+package routes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/duncanleo/plex-dvr-hls/config"
+	"github.com/gin-gonic/gin"
+)
+
+// TestXMLTVChannelIteration verifies XMLTV includes all channels from
+// config.GetChannels() in its output.
+func TestXMLTVChannelIteration(t *testing.T) {
+	t.Cleanup(func() { config.SetChannels(nil) })
+	config.SetChannels([]config.Channel{
+		{Name: "News Channel", URL: "http://stream1.com"},
+		{Name: "Sports Channel", URL: "http://stream2.com"},
+	})
+
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodGet, "/xmltv", nil)
+
+	XMLTV(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	body := w.Body.String()
+	for _, name := range []string{"News Channel", "Sports Channel"} {
+		if !strings.Contains(body, name) {
+			t.Errorf("expected %q in XMLTV output", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **Stream reliability** — replace byte-count-based failure detection with a time-based restart cap: ffmpeg is restarted on drop with a 2s delay; after 3 consecutive exits that each lasted under 10s the handler gives up (returns 502 if no bytes were written, otherwise closes the connection). `ctx.Err()` is checked unconditionally after `io.Copy` so a SIGKILL'd ffmpeg is correctly detected. `-reconnect` flags are now gated behind an HTTP(S) URL prefix check — they are invalid for RTSP/UDP sources.
- **Mutex safety** — `config.Channels` is unexported; all access goes through `SetChannels` / `GetChannels` / `GetChannel` / `GetChannelCount`, each holding the mutex. `loadChannelsFromFile` now rejects an empty decode result so a bad reload preserves the previous channel list.
- **Clean shutdown** — replace `log.Fatalf` goroutine in `cmd/main.go` with a `serverErr` channel so OS signals and server errors both flow through the same `select`, ensuring `serverCancel()` is always called before `Shutdown()`.
- **Template embed** — `//go:embed` bakes `xmltv.tmpl` into the binary at compile time. The `templates/` directory is no longer required at runtime; the Dockerfile `COPY templates/` layer is removed.
- **Bug fix** — `SourceList` JSON struct tag in `routes/lineup.go` was incorrectly set to `"Cable"`.
- **Tests** — added coverage for config (mutex safety, empty-reload guard, fsnotify watch loop), stream (retry loop, context cancellation, server-ctx cancellation, healthy-reset, start failure, RTSP reconnect flag gating), lineup, xmltv, and discover routes.
- **Docs** — README removes stale "copy templates folder" step, adds environment variables table (`PORT`, `PLAYLIST`, `UA`), and clarifies the stream retry cap. `channels.example.json` gains a dedicated entry showing all optional fields.

## Test plan

- [ ] `go test ./...` passes
- [ ] `go test -race ./...` passes with no race reports
- [ ] `go build ./...` succeeds
- [ ] Add server to Plex at `http://<host>:5004` and verify channel lineup loads
- [ ] Verify XMLTV EPG loads at `http://<host>:5004/xmltv`
- [ ] Edit `channels.json` while server is running and verify hot-reload fires