### PR TITLE
fix: make -reconnect_at_eof opt-in; restore WORKDIR /app in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN case ${TARGETPLATFORM:-linux/amd64} in \
     *)             apk add ffmpeg ;; \
     esac
 
+WORKDIR /app
+
 COPY --from=app-build /bin/app /bin/app
 
 ENTRYPOINT ["/bin/app"]

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ services:
      | `url` | string | Stream URL (M3U8, RTSP, or any ffmpeg-supported input) |
      | `disableTranscode` | bool | Pass video through unchanged (`-c:v copy`) instead of re-encoding |
      | `disableAudioTranscode` | bool | Pass audio through unchanged (`-c:a copy`) instead of re-encoding at 256k |
+     | `reconnect` | bool | Enable `-reconnect_at_eof` and `-reconnect_streamed` for this channel. **Off by default.** HLS sources must leave this off — those flags cause an infinite loop when the provider 302-redirects each playlist request to a rotating backend. Enable only for direct MPEG-TS or other non-HLS HTTP sources. |
      | `userAgent` | string | Custom `User-Agent` header sent to the stream source |
      | `referer` | string | Custom `Referer` header sent to the stream source |
      | `icon` | string | URL to channel logo (used in XMLTV EPG) |

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ services:
      | `url` | string | Stream URL (M3U8, RTSP, or any ffmpeg-supported input) |
      | `disableTranscode` | bool | Pass video through unchanged (`-c:v copy`) instead of re-encoding |
      | `disableAudioTranscode` | bool | Pass audio through unchanged (`-c:a copy`) instead of re-encoding at 256k |
-     | `reconnect` | bool | Enable `-reconnect_at_eof` and `-reconnect_streamed` for this channel. **Off by default.** HLS sources must leave this off — those flags cause an infinite loop when the provider 302-redirects each playlist request to a rotating backend. Enable only for direct MPEG-TS or other non-HLS HTTP sources. |
+     | `reconnect` | bool | Enable `-reconnect_at_eof` and `-reconnect_streamed` for this channel. **Off by default.** HLS sources (URLs ending in `.m3u8`, or any URL served via the HLS demuxer) must leave this off — those flags cause an infinite loop when the provider 302-redirects each playlist request to a rotating backend. Enable only for direct MPEG-TS or other non-HLS HTTP sources (e.g. `http://host/stream.ts`, `http://host:8080/udp/239.x.x.x:port`). |
      | `userAgent` | string | Custom `User-Agent` header sent to the stream source |
      | `referer` | string | Custom `Referer` header sent to the stream source |
      | `icon` | string | URL to channel logo (used in XMLTV EPG) |

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ services:
      | `url` | string | Stream URL (M3U8, RTSP, or any ffmpeg-supported input) |
      | `disableTranscode` | bool | Pass video through unchanged (`-c:v copy`) instead of re-encoding |
      | `disableAudioTranscode` | bool | Pass audio through unchanged (`-c:a copy`) instead of re-encoding at 256k |
-     | `reconnect` | bool | Enable `-reconnect_at_eof` and `-reconnect_streamed` for this channel. **Off by default.** HLS sources (URLs ending in `.m3u8`, or any URL served via the HLS demuxer) must leave this off — those flags cause an infinite loop when the provider 302-redirects each playlist request to a rotating backend. Enable only for direct MPEG-TS or other non-HLS HTTP sources (e.g. `http://host/stream.ts`, `http://host:8080/udp/239.x.x.x:port`). |
+     | `reconnect` | bool | Enable `-reconnect_at_eof` and `-reconnect_streamed` for this channel. **Off by default** — HLS sources must leave this off (causes infinite reconnect loop on providers with rotating 302 redirects). Enable only for direct MPEG-TS or other non-HLS HTTP sources (e.g. `http://host/stream.ts`). |
      | `userAgent` | string | Custom `User-Agent` header sent to the stream source |
      | `referer` | string | Custom `Referer` header sent to the stream source |
      | `icon` | string | URL to channel logo (used in XMLTV EPG) |

--- a/channels.example.json
+++ b/channels.example.json
@@ -1,16 +1,21 @@
 [
   {
-    "name": "Al Jazeera English",
+    "name": "Al Jazeera English (HLS)",
     "url": "http://aljazeera-eng-hd-live.hls.adaptive.level3.net/aljazeera/english2/index.m3u8"
   },
   {
-    "name": "PGA Tour on CBS",
+    "name": "PGA Tour on CBS (HLS via proxy)",
     "url": "http://cbssportsliveios-i.akamaihd.net/hls/live/207523/pgatour_simulcast/desktop.m3u8",
     "proxy": {
       "host": "proxy.somewhere.com:3128",
       "username": "",
       "password": ""
     }
+  },
+  {
+    "name": "Direct MPEG-TS stream (reconnect safe)",
+    "url": "http://example.com:8080/stream.ts",
+    "reconnect": true
   },
   {
     "name": "Example with all optional fields",

--- a/channels.example.json
+++ b/channels.example.json
@@ -17,6 +17,7 @@
     "url": "rtsp://example.com/stream",
     "disableTranscode": true,
     "disableAudioTranscode": true,
+    "reconnect": false,
     "userAgent": "Mozilla/5.0",
     "referer": "https://example.com",
     "icon": "https://example.com/icon.png"

--- a/config/channels.go
+++ b/config/channels.go
@@ -25,6 +25,13 @@ type Channel struct {
 	ProxyConfig           *ProxyConfig `json:"proxy"`
 	DisableTranscode      bool         `json:"disableTranscode"`
 	DisableAudioTranscode bool         `json:"disableAudioTranscode"`
+	// Reconnect enables -reconnect_at_eof and -reconnect_streamed for HTTP(S)
+	// sources. Off by default: the HLS demuxer manages its own segment cycling
+	// and treats a normal playlist-fetch EOF as a reconnect trigger, which
+	// causes an infinite loop on providers that 302-redirect each request to a
+	// fresh backend. Enable only for direct MPEG-TS or other non-HLS HTTP
+	// sources that need low-level reconnect on EOF.
+	Reconnect bool `json:"reconnect"`
 
 	// UserAgent is a custom UA string that will be used by FFMPEG to make requests to the stream URL.
 	UserAgent *string `json:"userAgent,omitempty"`

--- a/config/channels_test.go
+++ b/config/channels_test.go
@@ -127,6 +127,31 @@ func TestLoadChannelsFromFileEmptyRejectsAndKeepsPrevious(t *testing.T) {
 	}
 }
 
+// TestLoadChannelsFromFileReconnectTag verifies that the Reconnect field is
+// correctly unmarshaled from JSON. A mistyped json tag (e.g. "Reconnect"
+// instead of "reconnect") would silently leave the field as false even when
+// channels.json sets it to true, making the feature undetectable without this test.
+func TestLoadChannelsFromFileReconnectTag(t *testing.T) {
+	t.Cleanup(func() { channels = nil })
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "channels.json")
+	content := `[{"name":"live","url":"http://example.com/stream.ts","reconnect":true}]`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := loadChannelsFromFile(path); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ch, ok := GetChannel(0)
+	if !ok {
+		t.Fatal("channel not found")
+	}
+	if !ch.Reconnect {
+		t.Error("Reconnect should be true after loading from JSON with \"reconnect\":true — check json struct tag")
+	}
+}
+
 // TestRunWatchLoopAtomicSave verifies that renaming a temp file over channels.json
 // (the standard atomic-save pattern used by editors and deployment tooling) triggers
 // a reload. Previously the Remove/Rename branch only re-added the watch without

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,5 @@ services:
         source: './channels.json'
         target: '/app/channels.json'
         read_only: true
-      - type: bind
-        source: './templates'
-        target: '/app/templates'
-        read_only: true
     ports:
       - '5004:5004'

--- a/routes/stream.go
+++ b/routes/stream.go
@@ -84,13 +84,15 @@ func buildFFmpegArgs(channel config.Channel, transcode string) []string {
 
 	// -reconnect* flags are HTTP(S)-only; passing them to RTSP or other
 	// protocols causes ffmpeg to error on startup.
+	// -reconnect_at_eof and -reconnect_streamed are opt-in (channel.Reconnect)
+	// because they break HLS sources whose provider 302-redirects each request
+	// to a rotating backend: the HLS demuxer's normal playlist-fetch EOF is
+	// misread as a dropped connection and triggers an infinite reconnect loop.
 	if strings.HasPrefix(channel.URL, "http://") || strings.HasPrefix(channel.URL, "https://") {
-		args = append(args,
-			"-reconnect", "1",
-			"-reconnect_at_eof", "1",
-			"-reconnect_streamed", "1",
-			"-reconnect_delay_max", "5",
-		)
+		args = append(args, "-reconnect", "1", "-reconnect_delay_max", "5")
+		if channel.Reconnect {
+			args = append(args, "-reconnect_at_eof", "1", "-reconnect_streamed", "1")
+		}
 	}
 
 	args = append(args, "-i", channel.URL)

--- a/routes/stream.go
+++ b/routes/stream.go
@@ -84,10 +84,8 @@ func buildFFmpegArgs(channel config.Channel, transcode string) []string {
 
 	// -reconnect* flags are HTTP(S)-only; passing them to RTSP or other
 	// protocols causes ffmpeg to error on startup.
-	// -reconnect_at_eof and -reconnect_streamed are opt-in (channel.Reconnect)
-	// because they break HLS sources whose provider 302-redirects each request
-	// to a rotating backend: the HLS demuxer's normal playlist-fetch EOF is
-	// misread as a dropped connection and triggers an infinite reconnect loop.
+	// -reconnect_at_eof/-reconnect_streamed are opt-in via channel.Reconnect
+	// (see Channel.Reconnect doc for why they are off by default).
 	if strings.HasPrefix(channel.URL, "http://") || strings.HasPrefix(channel.URL, "https://") {
 		args = append(args, "-reconnect", "1", "-reconnect_delay_max", "5")
 		if channel.Reconnect {

--- a/routes/stream_test.go
+++ b/routes/stream_test.go
@@ -577,11 +577,8 @@ func TestBuildFFmpegArgsReconnect(t *testing.T) {
 	}
 }
 
-// TestBuildFFmpegArgsReconnectAtEofNotDefault confirms the bug fix: HLS sources
-// with rotating redirect targets loop forever when -reconnect_at_eof is set,
-// because each normal playlist-fetch EOF triggers a spurious low-level
-// reconnect before the HLS demuxer can process the response. These flags must
-// NOT be added unless the channel explicitly opts in via Reconnect: true.
+// TestBuildFFmpegArgsReconnectAtEofNotDefault confirms that -reconnect_at_eof
+// and -reconnect_streamed are absent by default (see Channel.Reconnect doc).
 func TestBuildFFmpegArgsReconnectAtEofNotDefault(t *testing.T) {
 	channel := config.Channel{Name: "test", URL: "https://example.com/live.m3u8"}
 	args := buildFFmpegArgs(channel, "")
@@ -625,9 +622,8 @@ func TestBuildFFmpegArgsReconnectRTSP(t *testing.T) {
 }
 
 // TestBuildFFmpegArgsReconnectOptInRTSP verifies that Reconnect:true on an RTSP
-// channel does not add any reconnect flags. The HTTP(S) guard must be the sole
-// gate — a future refactor that hoists Reconnect:true outside that guard would
-// silently break RTSP streams, which this test catches.
+// channel still produces no reconnect flags — the HTTP(S) URL guard is the
+// sole gate, not the Reconnect field alone.
 func TestBuildFFmpegArgsReconnectOptInRTSP(t *testing.T) {
 	channel := config.Channel{Name: "test", URL: "rtsp://camera.local/stream", Reconnect: true}
 	args := buildFFmpegArgs(channel, "")

--- a/routes/stream_test.go
+++ b/routes/stream_test.go
@@ -560,28 +560,52 @@ func findInputIdx(args []string) int {
 	return -1
 }
 
-// TestBuildFFmpegArgsReconnect verifies that reconnect flags are present before
-// -i so ffmpeg automatically recovers from upstream HLS hiccups instead of
-// exiting and dropping the Plex stream permanently.
+// TestBuildFFmpegArgsReconnect verifies that -reconnect is present before -i
+// for HTTP(S) sources so ffmpeg recovers from true connection drops.
 func TestBuildFFmpegArgsReconnect(t *testing.T) {
 	channel := config.Channel{Name: "test", URL: "http://example.com/stream.m3u8"}
 	args := buildFFmpegArgs(channel, "")
 
-	iIdx := -1
-	for i, a := range args {
-		if a == "-i" {
-			iIdx = i
-			break
-		}
-	}
+	iIdx := findInputIdx(args)
 	if iIdx == -1 {
 		t.Fatal("-i flag not found in args")
 	}
 	preInput := args[:iIdx]
 
-	for _, flag := range []string{"-reconnect", "-reconnect_at_eof", "-reconnect_streamed"} {
+	if !contains(preInput, "-reconnect") {
+		t.Error("-reconnect missing before -i — stream will not recover from upstream drops")
+	}
+}
+
+// TestBuildFFmpegArgsReconnectAtEofNotDefault confirms the bug fix: HLS sources
+// with rotating redirect targets loop forever when -reconnect_at_eof is set,
+// because each normal playlist-fetch EOF triggers a spurious low-level
+// reconnect before the HLS demuxer can process the response. These flags must
+// NOT be added unless the channel explicitly opts in via Reconnect: true.
+func TestBuildFFmpegArgsReconnectAtEofNotDefault(t *testing.T) {
+	channel := config.Channel{Name: "test", URL: "https://example.com/live.m3u8"}
+	args := buildFFmpegArgs(channel, "")
+	for _, flag := range []string{"-reconnect_at_eof", "-reconnect_streamed"} {
+		if contains(args, flag) {
+			t.Errorf("flag %q must not be present by default — breaks HLS streams with rotating redirect targets", flag)
+		}
+	}
+}
+
+// TestBuildFFmpegArgsReconnectOptIn verifies that a channel with Reconnect:true
+// gets the full set of reconnect flags including -reconnect_at_eof and
+// -reconnect_streamed, for sources (e.g. direct MPEG-TS over HTTP) that need them.
+func TestBuildFFmpegArgsReconnectOptIn(t *testing.T) {
+	channel := config.Channel{Name: "test", URL: "https://example.com/stream.ts", Reconnect: true}
+	args := buildFFmpegArgs(channel, "")
+	iIdx := findInputIdx(args)
+	if iIdx == -1 {
+		t.Fatal("-i flag not found in args")
+	}
+	preInput := args[:iIdx]
+	for _, flag := range []string{"-reconnect", "-reconnect_at_eof", "-reconnect_streamed", "-reconnect_delay_max"} {
 		if !contains(preInput, flag) {
-			t.Errorf("reconnect flag %q missing before -i — stream will not recover from upstream drops", flag)
+			t.Errorf("flag %q missing before -i for channel with Reconnect:true", flag)
 		}
 	}
 }

--- a/routes/stream_test.go
+++ b/routes/stream_test.go
@@ -624,6 +624,20 @@ func TestBuildFFmpegArgsReconnectRTSP(t *testing.T) {
 	}
 }
 
+// TestBuildFFmpegArgsReconnectOptInRTSP verifies that Reconnect:true on an RTSP
+// channel does not add any reconnect flags. The HTTP(S) guard must be the sole
+// gate — a future refactor that hoists Reconnect:true outside that guard would
+// silently break RTSP streams, which this test catches.
+func TestBuildFFmpegArgsReconnectOptInRTSP(t *testing.T) {
+	channel := config.Channel{Name: "test", URL: "rtsp://camera.local/stream", Reconnect: true}
+	args := buildFFmpegArgs(channel, "")
+	for _, flag := range []string{"-reconnect", "-reconnect_at_eof", "-reconnect_streamed", "-reconnect_delay_max"} {
+		if contains(args, flag) {
+			t.Errorf("RTSP URL with Reconnect:true: flag %q must not be present — HTTP(S) guard must be the sole gate", flag)
+		}
+	}
+}
+
 // TestBuildFFmpegArgsAudioTranscode verifies disableAudioTranscode switches
 // from re-encoding audio at 256k to passing the source audio through unchanged.
 func TestBuildFFmpegArgsAudioTranscode(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Bug fix** — drop `-reconnect_at_eof` and `-reconnect_streamed` from the default ffmpeg args for HTTP(S) sources. These flags cause an infinite loop for HLS streams from providers that 302-redirect each playlist request to a rotating backend subdomain: the HLS demuxer's normal playlist-fetch EOF is intercepted at the HTTP layer and triggers a full reconnect before the demuxer can process the response, cycling forever with zero bytes reaching the client.
- **Per-channel opt-in** — add `"reconnect": bool` field to `channels.json`. Defaults to `false` (safe for all HLS). Set `true` for direct MPEG-TS or other non-HLS HTTP sources (e.g. `http://host/stream.ts`) that need `-reconnect_at_eof` and `-reconnect_streamed`.
- **Docker fixes** — restore `WORKDIR /app` in the runtime stage (lost when the templates layer was removed in #53; without it the binary runs from `/` and cannot find `channels.json`/`config.json` mounted at `/app/`). Remove stale `templates` bind mount from `docker-compose.yml` (template is now embedded in the binary).

## Relates to

Closes #54 

## Test plan

- [ ] `go test ./...` passes
- [ ] `go test -race ./...` passes
- [ ] HLS `.m3u8` stream from a provider with rotating 302 redirects plays without looping
- [ ] Channel with `"reconnect": true` and a direct MPEG-TS source includes `-reconnect_at_eof` in ffmpeg args
- [ ] Docker image starts and finds `config.json` / `channels.json` at `/app/`